### PR TITLE
remove path separator prefix for tx submission

### DIFF
--- a/horizon.go
+++ b/horizon.go
@@ -898,7 +898,7 @@ func (net *StellarNet) Post(e *TransactionEnvelope) (
 		return nil, badHorizonURL
 	}
 	tx := stcdetail.XdrToBase64(e)
-	resp, err := http.PostForm(net.Horizon+"/transactions",
+	resp, err := http.PostForm(net.Horizon + "transactions/",
 		url.Values{"tx": {tx}})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* add path separator suffix for `transactions/` endpoint

This PR fixes a double slash transaction submission error when connecting to custom horizon endpoints such as `http://localhost:8000/`

```
[pid 14649] write(3, "POST //transactions HTTP/1.1\r\nHo"..., 498) = 498
[pid 14649] write(2, "Post transaction failed: EOF\n", 29Post transaction failed: EOF
```