### PR TITLE
Fix build in Go 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ go.mod: $(MAKEFILE_LIST)
 	    export GOPRIVATE='*'; \
 	    go get -u github.com/xdrpp/goxdr/cmd/goxdr; \
 	fi
+	go mod tidy
 
 $(XDRS): xdr
 


### PR DESCRIPTION
### What
Add `go mod tidy` to the build process of go.mod.

### Why
In Go 1.16 or one of the other recent releases of Go the `go build` command was changed so that it will not modify the go.mod file on its own. It used to modify the file adding any missing dependencies. Now the only command that will modify the file on its own is `go mod tidy`. This makes the building process more predictable since we can now rely on `go build` not changing dependency definitions.

The build process for stc blows away the go.mod file and recreates it, but it doesn't recreate it with all the dependencies the code has.

In Go 1.16 if you run `make depend` then `make` I see this error:
```
...
go build
privkey.go:10:2: no required module provides package golang.org/x/crypto/openpgp; to add it:
        go get golang.org/x/crypto/openpgp
privkey.go:11:2: no required module provides package golang.org/x/crypto/openpgp/armor; to add it:
        go get golang.org/x/crypto/openpgp/armor
privkey.go:12:2: no required module provides package golang.org/x/crypto/openpgp/packet; to add it:
        go get golang.org/x/crypto/openpgp/packet
stcdetail/crypto.go:12:2: no required module provides package golang.org/x/crypto/ssh/terminal; to add it:
        go get golang.org/x/crypto/ssh/terminal
make: *** [Makefile:11: build] Error 1
```

Adding `go mod tidy` will update the `go.mod` file so that it contains all its dependencies.