### PR TITLE
Add standalone network used in docker standalone configurations

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ native-asset = TestXLM
 
 [net "standalone"]
 network-id = "Standalone Network ; February 2017"
+horizon = http://localhost:8000/
 
 `)
 

--- a/config.go
+++ b/config.go
@@ -31,6 +31,9 @@ native-asset = XLM
 horizon = https://horizon-testnet.stellar.org/
 native-asset = TestXLM
 
+[net "standalone"]
+network-id = "Standalone Network ; February 2017"
+
 `)
 
 var globalConfigContents []byte

--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ native-asset = TestXLM
 [net "standalone"]
 network-id = "Standalone Network ; February 2017"
 horizon = http://localhost:8000/
+native-asset = StandaloneXLM
 
 `)
 


### PR DESCRIPTION
### What
Add the standalone network that is used in the official Stellar Docker images to the built-in config.

### Why
The official Stellar Docker images ship with three networks, pubnet, testnet, and standalone. Standalone is useful for private testing and development. It'd be convenient if stc shipped with built-in support for the standalone network so that when testing with the docker images in standalone mode we didn't have to setup the network manually each time in stc config.

https://github.com/stellar/docker-stellar-core-horizon/blob/23e8df8/standalone/core/etc/stellar-core.cfg#L9
