### PR TITLE
Fix non-vim editors

### DIFF
--- a/cmd/stc/stc.go
+++ b/cmd/stc/stc.go
@@ -317,10 +317,10 @@ func editor(path string, line int) {
 	edArgv := strings.Split(ed, " ")
 	var argv []string
 	switch edArgv[0] {
-	case "vi", "vim":
-		argv = append(edArgv, fmt.Sprintf("+%d", line), path)
-	default:
+	case "code": // Visual Studio Code
 		argv = append(edArgv, path)
+	default: // Vi, vim, emacs, ex, etc
+		argv = append(edArgv, fmt.Sprintf("+%d", line), path)
 	}
 	if path, err := exec.LookPath(argv[0]); err == nil {
 		argv[0] = path


### PR DESCRIPTION
### What
Change the editor subprocess execution to only include `+0` for vi/vim, and split the options in a simple `EDITOR`/`STCEDITOR`.

### Why
Stc doesn't appear to support vscode as an editor, and I imagine some other non-vim editors. This appears to be for several reasons.

1. It assumes the `EDITOR` or `STCEDITOR` is a command without args. VSCode needs to be executed with `code -w` when opening a file that the caller wishes to wait on closing.

2. When opening in vscode, it instructs it to open two files, a 0 file and a stc file, because it always passes the `+<line>` option to the command. That command is only valid for vi/vim.
